### PR TITLE
[RELEASE] Version 3.0.1 - Enhance Android Spotify integration and key…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - Release 2026-03-24
+
+### Added
+- **Android: "Open Spotify" button in match center control panel** — tapping the green `open_in_new` icon launches the Spotify app directly via `spotify:` URI (`url_launcher`); previously the button was iOS/macOS only
+- **Android: volume initialised from platform on startup** — `SpotifyRemoteRepository` now reads the real system volume immediately on construction instead of defaulting to 50%
+- **Android: auto-set volume to 85% when muted on startup** — if the device volume is 0 when the app launches, it is automatically raised to 85% and a toast "Volume auto-set to 85%" is shown
+
+### Fixed
+- **Android: volume not restored after pause → play (no start time)** — `pausePlayer()` now saves the pre-mute volume in `_preMuteVolume`; `_unMute()` restores from that value so the volume listener overwriting `repo.volume` to 0 no longer causes silent playback
+- **Android: volume stuck when increasing** — Android media volume uses discrete integer steps (~15); adding 0.05 often floor-truncates to the same step. Now detects a no-change and retries with a 0.07 bump (> 1/15 step size) to guarantee advancement
+- **Android: incorrect volume restore after pause → play with start time** — introduced `_isMuted` flag; repo-level `_unMute()` is now only called after `playWithPosition` when we explicitly muted on pause, preventing stale `_preMuteVolume` from overriding the bridge's correct restore when switching tracks without pausing first
+- **Android build: upgraded AGP 8.6.0 → 8.9.1 and Gradle wrapper 8.7 → 8.11.1** — required by `url_launcher_android 6.3.x` / `androidx.browser 1.9.0`
+
 ## [3.0.0] - Release 2026-03-23
 
 ### Changed

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id 'org.gradle.toolchains.foojay-resolver-convention' version "0.8.0"
 }

--- a/lib/data/repo/app_settings_repository.dart
+++ b/lib/data/repo/app_settings_repository.dart
@@ -5,6 +5,7 @@ import 'package:hive_ce/hive.dart';
 class AppSettings {
   static const _boxName = 'settings';
   static const _sidebarOnRightKey = 'sidebarOnRight';
+  static const _keyboardShortcutsEnabledKey = 'keyboardShortcutsEnabled';
 
   static Box<dynamic> get _box => Hive.box<dynamic>(_boxName);
 
@@ -15,4 +16,12 @@ class AppSettings {
 
   static Future<void> setSidebarOnRight(bool value) =>
       _box.put(_sidebarOnRightKey, value);
+
+  /// Whether keyboard shortcuts are enabled in the match center.
+  /// Defaults to false.
+  static bool get keyboardShortcutsEnabled =>
+      _box.get(_keyboardShortcutsEnabledKey, defaultValue: false) as bool;
+
+  static Future<void> setKeyboardShortcutsEnabled(bool value) =>
+      _box.put(_keyboardShortcutsEnabledKey, value);
 }

--- a/lib/data/repo/spotify_remote_repository.dart
+++ b/lib/data/repo/spotify_remote_repository.dart
@@ -12,10 +12,27 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:spotify/spotify.dart';
 
 class SpotifyRemoteRepository {
-  SpotifyRemoteRepository(this._credentials, this._spotifyRedirectUrl);
+  SpotifyRemoteRepository(this._credentials, this._spotifyRedirectUrl) {
+    _initVolume();
+  }
   final SpotifyApiCredentials _credentials;
   final String _spotifyRedirectUrl;
   final SpotifyPlatformBridge _bridge = SpotifyPlatformBridge();
+
+  Future<void> _initVolume() async {
+    final v = await _bridge.getSystemVolume();
+    if (v == 0) {
+      await _bridge.setSystemVolume(0.85);
+      volume = 0.85;
+      _preMuteVolume = 0.85;
+      volumeNotifier.value = 0.85;
+      volumeAutoSetToDefault = true;
+    } else {
+      volume = v;
+      _preMuteVolume = v;
+      volumeNotifier.value = v;
+    }
+  }
 
   String lastValidAccessToken = '';
   Object lastAccessTokenError = Object();
@@ -30,6 +47,9 @@ class SpotifyRemoteRepository {
   bool _isConnecting = false;
   bool get isConnecting => _isConnecting;
   double volume = 0.5;
+  double _preMuteVolume = 0.5;
+  bool _isMuted = false;
+  bool volumeAutoSetToDefault = false;
   final ValueNotifier<double> volumeNotifier = ValueNotifier(0.5);
   /// True on iOS when the silence keep-alive track is playing instead of
   /// real music (i.e. the user pressed pause).
@@ -65,6 +85,21 @@ class SpotifyRemoteRepository {
     volume = rounded;
     volumeNotifier.value = rounded;
     await _bridge.setSystemVolume(rounded);
+    // Android uses discrete integer volume steps (typically 15 on the media
+    // stream). setVolume() floor-truncates the float, so adding 0.05 often
+    // maps to the same step and produces no change when increasing.
+    // If the system volume didn't advance, bump by 0.07 (> 1/15 ≈ 0.067)
+    // to guarantee crossing into the next step.
+    if (Platform.isAndroid && adjustment > 0) {
+      final actual = await _bridge.getSystemVolume();
+      if (actual <= currentVolume + 0.001) {
+        final bumped = (currentVolume + 0.07).clamp(0.0, 1.0);
+        await _bridge.setSystemVolume(bumped);
+        final finalActual = await _bridge.getSystemVolume();
+        volume = finalActual;
+        volumeNotifier.value = finalActual;
+      }
+    }
   }
 
   Future<void> launchSpotify() => _bridge.launchSpotify();
@@ -253,16 +288,21 @@ class SpotifyRemoteRepository {
   }
 
   Future<void> _mute() async {
+    _isMuted = true;
     await _bridge.setSystemVolume(0);
   }
 
   Future<void> _unMute() async {
-    await _bridge.setSystemVolume(volume);
+    _isMuted = false;
+    await _bridge.setSystemVolume(_preMuteVolume);
   }
 
   Future<bool> pausePlayer() async {
     try {
-      if (Platform.isAndroid) await _mute();
+      if (Platform.isAndroid) {
+        _preMuteVolume = volume;
+        await _mute();
+      }
       await _bridge.pause();
       if (Platform.isIOS) silencePlayingNotifier.value = true;
       SpotifyConnectionLog().addSimpleEntry(
@@ -368,6 +408,10 @@ class SpotifyRemoteRepository {
         spotifyUri: track.spotifyUri,
         positionMs: jumpStart > 0 ? jumpStart : 0,
       );
+      // Only restore volume if we explicitly muted on pause. When playing
+      // with a start time without a prior pause, the bridge handles its own
+      // mute/unmute internally using the correct pre-seek volume.
+      if (Platform.isAndroid && _isMuted) await _unMute();
       debugPrint('[PLAY] bridge.playWithPosition returned OK');
       if (jumpStart > 0) {
         latestDurationStartupMS = DateTime.now()

--- a/lib/data/services/spotify_platform_bridge.dart
+++ b/lib/data/services/spotify_platform_bridge.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_volume_controller/flutter_volume_controller.dart';
 import 'package:spotify_sdk/spotify_sdk.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 abstract class SpotifyPlatformBridge {
   factory SpotifyPlatformBridge() {
@@ -404,7 +405,8 @@ class _AndroidBridge implements SpotifyPlatformBridge {
       FlutterVolumeController.setVolume(volume);
 
   @override
-  Future<void> launchSpotify() async {}
+  Future<void> launchSpotify() =>
+      launchUrl(Uri.parse('spotify:'), mode: LaunchMode.externalApplication);
 
   @override
   Future<Map<String, String>> getUserProfile() async => {};

--- a/lib/features/djmatch_center/djmatch_center.dart
+++ b/lib/features/djmatch_center/djmatch_center.dart
@@ -1,8 +1,10 @@
 import 'package:djsports/data/models/djplaylist_model.dart';
 import 'package:djsports/data/provider/djplaylist_provider.dart';
+import 'package:djsports/data/repo/app_settings_repository.dart';
 import 'package:djsports/data/repo/spotify_remote_repository.dart';
 import 'package:djsports/features/djmatch_center/widgets/djmatch_center_playlist_tracks_carousel.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'dart:io';
 
@@ -24,8 +26,120 @@ class _DJMatchCenterViewPageState extends ConsumerState<DJMatchCenterViewPage> {
   bool spotifyRemoteConnect = false;
   bool isPlaying = false;
 
+  // Keyboard shortcut play triggers keyed by playlist id
+  final Map<String, ValueNotifier<int>> _playTriggers = {};
+
+  static const _hotspotKeys = ['1', '2', '3', '4', '5', '6'];
+  static const _matchKeys = ['q', 'w', 'e', 'r', 't', 'y'];
+  static const _funStuffKeys = ['a', 's', 'd', 'f', 'g', 'h'];
+
+  static const _hotspotLogicalKeys = [
+    LogicalKeyboardKey.digit1,
+    LogicalKeyboardKey.digit2,
+    LogicalKeyboardKey.digit3,
+    LogicalKeyboardKey.digit4,
+    LogicalKeyboardKey.digit5,
+    LogicalKeyboardKey.digit6,
+  ];
+  static const _matchLogicalKeys = [
+    LogicalKeyboardKey.keyQ,
+    LogicalKeyboardKey.keyW,
+    LogicalKeyboardKey.keyE,
+    LogicalKeyboardKey.keyR,
+    LogicalKeyboardKey.keyT,
+    LogicalKeyboardKey.keyY,
+  ];
+  static const _funStuffLogicalKeys = [
+    LogicalKeyboardKey.keyA,
+    LogicalKeyboardKey.keyS,
+    LogicalKeyboardKey.keyD,
+    LogicalKeyboardKey.keyF,
+    LogicalKeyboardKey.keyG,
+    LogicalKeyboardKey.keyH,
+  ];
+
+  ValueNotifier<int> _getTrigger(String playlistId) =>
+      _playTriggers.putIfAbsent(playlistId, () => ValueNotifier(0));
+
+  String? _shortcutKeyForType(DJPlaylistType type, int index) {
+    if (index >= 6) return null;
+    if (type == DJPlaylistType.hotspot) return _hotspotKeys[index];
+    if (type == DJPlaylistType.match) return _matchKeys[index];
+    if (type == DJPlaylistType.funStuff) return _funStuffKeys[index];
+    return null;
+  }
+
+  bool _handleKeyEvent(KeyEvent event) {
+    if (!AppSettings.keyboardShortcutsEnabled) return false;
+
+    // Consume key-repeat for all our keys to prevent OS beep on held keys
+    if (event is KeyRepeatEvent) {
+      final k = event.logicalKey;
+      return _hotspotLogicalKeys.contains(k) ||
+          _matchLogicalKeys.contains(k) ||
+          _funStuffLogicalKeys.contains(k) ||
+          k == LogicalKeyboardKey.escape ||
+          k == LogicalKeyboardKey.keyP ||
+          k == LogicalKeyboardKey.add ||
+          k == LogicalKeyboardKey.minus;
+    }
+    if (event is! KeyDownEvent) return false;
+
+    final key = event.logicalKey;
+
+    // Global transport controls
+    if (key == LogicalKeyboardKey.escape) {
+      pausePlayer();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.keyP) {
+      resumePlayer();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.add) {
+      ref.read(spotifyRemoteRepositoryProvider).adjustVolume(0.05);
+      return true;
+    }
+    if (key == LogicalKeyboardKey.minus) {
+      ref.read(spotifyRemoteRepositoryProvider).adjustVolume(-0.05);
+      return true;
+    }
+
+    // Playlist shortcuts
+    DJPlaylistType? type;
+    int index = -1;
+
+    if (_hotspotLogicalKeys.contains(key)) {
+      type = DJPlaylistType.hotspot;
+      index = _hotspotLogicalKeys.indexOf(key);
+    } else if (_matchLogicalKeys.contains(key)) {
+      type = DJPlaylistType.match;
+      index = _matchLogicalKeys.indexOf(key);
+    } else if (_funStuffLogicalKeys.contains(key)) {
+      type = DJPlaylistType.funStuff;
+      index = _funStuffLogicalKeys.indexOf(key);
+    }
+
+    // Not one of our shortcut keys — let OS handle it
+    if (type == null || index < 0) return false;
+
+    // It IS our shortcut key — consume it (prevents OS beep) even if no
+    // playlist exists at that index
+    final allPlaylists = ref.read(hivePlaylistData) ?? [];
+    final typePlaylists = allPlaylists
+        .where((p) => p.type == type!.name)
+        .toList()
+      ..sort((a, b) => a.position.compareTo(b.position));
+
+    if (index < typePlaylists.length) {
+      _getTrigger(typePlaylists[index].id).value++;
+    }
+    return true;
+  }
+
   @override
   void initState() {
+    HardwareKeyboard.instance.addHandler(_handleKeyEvent);
     if (!Platform.isMacOS) {
       FlutterVolumeController.addListener((newVolume) {
         final repo = ref.read(spotifyRemoteRepositoryProvider);
@@ -36,14 +150,25 @@ class _DJMatchCenterViewPageState extends ConsumerState<DJMatchCenterViewPage> {
       });
       FlutterVolumeController.getVolume().then((v) {
         if (v != null && mounted) {
-          ref.read(spotifyRemoteRepositoryProvider).setVolume(v);
-          final pct = (v * 100).round();
+          final repo = ref.read(spotifyRemoteRepositoryProvider);
+          final autoSet = repo.volumeAutoSetToDefault || v == 0;
+          if (autoSet) {
+            repo.volumeAutoSetToDefault = false;
+            if (v == 0) {
+              FlutterVolumeController.setVolume(0.85);
+              repo.setVolume(0.85);
+            }
+          } else {
+            repo.setVolume(v);
+          }
           final mq = MediaQuery.of(context);
           final bottomMargin =
               (mq.size.width < 600 || mq.size.height < 500) ? 110.0 : 0.0;
           toastification.show(
             context: context,
-            title: Text('Volume: $pct%'),
+            title: Text(
+              autoSet ? 'Volume auto-set to 85%' : 'Volume: ${(v * 100).round()}%',
+            ),
             autoCloseDuration: const Duration(seconds: 3),
             style: ToastificationStyle.flat,
             alignment: Alignment.bottomCenter,
@@ -57,6 +182,10 @@ class _DJMatchCenterViewPageState extends ConsumerState<DJMatchCenterViewPage> {
 
   @override
   void dispose() {
+    HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
+    for (final t in _playTriggers.values) {
+      t.dispose();
+    }
     if (!Platform.isMacOS) {
       FlutterVolumeController.removeListener();
     }
@@ -108,6 +237,9 @@ class _DJMatchCenterViewPageState extends ConsumerState<DJMatchCenterViewPage> {
           mainAxisSpacing: 5,
         ),
         delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+          final shortcutKey = AppSettings.keyboardShortcutsEnabled
+              ? _shortcutKeyForType(playlistType, index)
+              : null;
           return Container(
             margin: const EdgeInsets.all(0.0),
             child: DJCenterPlaylistTracksCarousel(
@@ -119,6 +251,10 @@ class _DJMatchCenterViewPageState extends ConsumerState<DJMatchCenterViewPage> {
               spotifyUri: playlistList[index].spotifyUri,
               currentTrack: playlistList[index].currentTrack,
               parentWidthSize: constGridItemWidth,
+              shortcutKey: shortcutKey,
+              playTrigger: shortcutKey != null
+                  ? _getTrigger(playlistList[index].id)
+                  : null,
             ),
           );
         }, childCount: playlistList.length),

--- a/lib/features/djmatch_center/widgets/center_control_widget.dart
+++ b/lib/features/djmatch_center/widgets/center_control_widget.dart
@@ -45,7 +45,7 @@ class _CenterControlWidgetState extends ConsumerState<CenterControlWidget> {
               icon: const Icon(Icons.play_arrow, color: Colors.white, size: 35),
               onPressed: widget.onResume,
             ),
-            if (Platform.isIOS || Platform.isMacOS) ...[
+            if (Platform.isIOS || Platform.isMacOS || Platform.isAndroid) ...[
               const Gap(4),
               IconButton(
                 icon: const Icon(

--- a/lib/features/djmatch_center/widgets/djmatch_center_playlist_tracks_carousel.dart
+++ b/lib/features/djmatch_center/widgets/djmatch_center_playlist_tracks_carousel.dart
@@ -21,6 +21,8 @@ class DJCenterPlaylistTracksCarousel extends HookConsumerWidget {
   final String spotifyUri;
   final int currentTrack;
   final int parentWidthSize;
+  final String? shortcutKey;
+  final ValueNotifier<int>? playTrigger;
 
   const DJCenterPlaylistTracksCarousel({
     super.key,
@@ -30,6 +32,8 @@ class DJCenterPlaylistTracksCarousel extends HookConsumerWidget {
     required this.spotifyUri,
     required this.currentTrack,
     required this.parentWidthSize,
+    this.shortcutKey,
+    this.playTrigger,
   });
 
   String printDurationWithMS(Duration duration, int ms) {
@@ -132,13 +136,181 @@ class DJCenterPlaylistTracksCarousel extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     DJPlaylist playlist = ref.watch(djPlaylistByIdProvider(playlistId));
-    //playlist =
-    //    ref.read(hivePlaylistData.notifier).shuffleTracksInPlaylist(playlistId);
     List<DJTrack> tracks =
         ref.watch(hiveTrackData.notifier).getDJTracks(playlist.trackIds);
 
     final carouselController = useMemoized(() => CarouselController());
     final isShowingPLAYFlame = useState(false);
+
+    // Refs so the keyboard effect always calls the latest playTrack version
+    final playTrackRef =
+        useRef<Future<void> Function(int)>((_) async {});
+    final tracksLengthRef = useRef(tracks.length);
+    tracksLengthRef.value = tracks.length;
+
+    Future<void> playTrack(int value) async {
+      DJTrack track = tracks[value];
+      String response = await ref
+          .read(spotifyRemoteRepositoryProvider)
+          .playTrackAndJumpStart(
+              track,
+              track.startTime + track.startTimeMS,
+              playlistType,
+              playlistName);
+
+      final isNoDevice = response.contains('[Error]') &&
+          (response.toLowerCase().contains('no active device') ||
+              response.toLowerCase().contains('player command failed'));
+      if (isNoDevice) {
+        final action = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('No Active Spotify Device'),
+            content: const Text(
+              'Spotify is not playing on any device.\n'
+              'Open the Spotify app and try again.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.open_in_new, size: 16),
+                label: const Text('Open Spotify'),
+                onPressed: () => Navigator.pop(ctx, true),
+              ),
+            ],
+          ),
+        );
+        if (action == true) {
+          await ref.read(spotifyRemoteRepositoryProvider).launchSpotify();
+        }
+      } else if (response.contains('[Error]')) {
+        final lower = response.toLowerCase();
+        final isReconnectError = lower.contains('not connected') ||
+            lower.contains('disconnected') ||
+            lower.contains('connection') ||
+            lower.contains('404') ||
+            lower.contains('401') ||
+            lower.contains('unauthorized');
+        if (isReconnectError) {
+          final reconnect = await showDialog<bool>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('Spotify Connection Error'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Lost connection to Spotify.\n'
+                    'Reconnect and try again?',
+                  ),
+                  const SizedBox(height: 8),
+                  SelectableText(
+                    response,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: Colors.red,
+                    ),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('Cancel'),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.pop(ctx, true),
+                  child: const Text('Force Full Reconnect'),
+                ),
+              ],
+            ),
+          );
+          if (reconnect == true) {
+            showMessageToast(context, 'Reconnecting to Spotify…');
+            final success = await ref
+                .read(spotifyRemoteRepositoryProvider)
+                .forceFullReconnect();
+            if (success) {
+              showMessageToast(context, 'Reconnected. Tap to retry.');
+            } else {
+              final err =
+                  ref.read(spotifyRemoteRepositoryProvider).lastConnectError;
+              showMessageToast(
+                context,
+                'Failed to reconnect${err.isNotEmpty ? ': $err' : ''}',
+              );
+            }
+          }
+        } else {
+          showMessageToast(context, response);
+        }
+      } else {
+        track.playCount = track.playCount + 1;
+        ref.read(hiveTrackData.notifier).updateDJTrack(track);
+        showMessageToast(context, response);
+      }
+
+      double newPosition =
+          (value * carouselController.position.viewportDimension) +
+              carouselController.position.viewportDimension;
+      isShowingPLAYFlame.value = true;
+      if (value == playlist.trackIds.length - 1) {
+        if (playlist.shuffleAtEnd) {
+          playlist = ref
+              .read(hivePlaylistData.notifier)
+              .shuffleTracksInPlaylist(playlistId);
+          tracks = ref
+              .watch(hiveTrackData.notifier)
+              .getDJTracks(playlist.trackIds);
+          newPosition = 0;
+          isShowingPLAYFlame.value = false;
+          await carouselController.position.animateTo(newPosition,
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.easeInOutCubicEmphasized);
+        }
+      } else {
+        await carouselController.position.animateTo(newPosition,
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeInOutCubicEmphasized);
+        Future.delayed(const Duration(milliseconds: 800), () {
+          isShowingPLAYFlame.value = false;
+        });
+        await ref
+            .read(lastDjTrackPlayedProvider.notifier)
+            .updateLastPlayedTrack(track);
+      }
+    }
+
+    // Always point to the latest playTrack (captures current tracks/playlist)
+    playTrackRef.value = playTrack;
+
+    // Keyboard shortcut trigger via ValueNotifier
+    useEffect(() {
+      final trigger = playTrigger;
+      if (trigger == null) return null;
+      void onTriggered() {
+        if (!context.mounted) return;
+        final length = tracksLengthRef.value;
+        if (length == 0) return;
+        int idx = 0;
+        if (carouselController.hasClients &&
+            carouselController.position.hasPixels &&
+            carouselController.position.viewportDimension > 0) {
+          idx = (carouselController.offset /
+                  carouselController.position.viewportDimension)
+              .round();
+        }
+        idx = idx.clamp(0, length - 1);
+        playTrackRef.value(idx);
+      }
+
+      trigger.addListener(onTriggered);
+      return () => trigger.removeListener(onTriggered);
+    }, const []);
 
     return Stack(children: [
       ScrollConfiguration(
@@ -153,146 +325,9 @@ class DJCenterPlaylistTracksCarousel extends HookConsumerWidget {
           scrollDirection: Axis.horizontal,
           itemExtent: double.infinity,
           controller: carouselController,
-          //itemExtent: 305,
           shrinkExtent: 200,
           backgroundColor: Colors.white,
-          onTap: (value) async {
-            DJTrack track = tracks[value];
-            String response = await ref
-                .read(spotifyRemoteRepositoryProvider)
-                .playTrackAndJumpStart(
-                    track,
-                    track.startTime + track.startTimeMS,
-                    playlistType,
-                    playlistName);
-
-            final isNoDevice = response.contains('[Error]') &&
-                (response.toLowerCase().contains('no active device') ||
-                    response.toLowerCase().contains('player command failed'));
-            if (isNoDevice) {
-              final action = await showDialog<bool>(
-                context: context,
-                builder: (ctx) => AlertDialog(
-                  title: const Text('No Active Spotify Device'),
-                  content: const Text(
-                    'Spotify is not playing on any device.\n'
-                    'Open the Spotify app and try again.',
-                  ),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(ctx, false),
-                      child: const Text('Cancel'),
-                    ),
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.open_in_new, size: 16),
-                      label: const Text('Open Spotify'),
-                      onPressed: () => Navigator.pop(ctx, true),
-                    ),
-                  ],
-                ),
-              );
-              if (action == true) {
-                await ref.read(spotifyRemoteRepositoryProvider).launchSpotify();
-              }
-            } else if (response.contains('[Error]')) {
-              final lower = response.toLowerCase();
-              final isReconnectError = lower.contains('not connected') ||
-                  lower.contains('disconnected') ||
-                  lower.contains('connection') ||
-                  lower.contains('404') ||
-                  lower.contains('401') ||
-                  lower.contains('unauthorized');
-              if (isReconnectError) {
-                final reconnect = await showDialog<bool>(
-                  context: context,
-                  builder: (ctx) => AlertDialog(
-                    title: const Text('Spotify Connection Error'),
-                    content: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          'Lost connection to Spotify.\n'
-                          'Reconnect and try again?',
-                        ),
-                        const SizedBox(height: 8),
-                        SelectableText(
-                          response,
-                          style: const TextStyle(
-                            fontSize: 11,
-                            color: Colors.red,
-                          ),
-                        ),
-                      ],
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(ctx, false),
-                        child: const Text('Cancel'),
-                      ),
-                      ElevatedButton(
-                        onPressed: () => Navigator.pop(ctx, true),
-                        child: const Text('Force Full Reconnect'),
-                      ),
-                    ],
-                  ),
-                );
-                if (reconnect == true) {
-                  showMessageToast(context, 'Reconnecting to Spotify…');
-                  final success = await ref
-                      .read(spotifyRemoteRepositoryProvider)
-                      .forceFullReconnect();
-                  if (success) {
-                    showMessageToast(context, 'Reconnected. Tap to retry.');
-                  } else {
-                    final err = ref
-                        .read(spotifyRemoteRepositoryProvider)
-                        .lastConnectError;
-                    showMessageToast(
-                      context,
-                      'Failed to reconnect${err.isNotEmpty ? ': $err' : ''}',
-                    );
-                  }
-                }
-              } else {
-                showMessageToast(context, response);
-              }
-            } else {
-              track.playCount = track.playCount + 1;
-              ref.read(hiveTrackData.notifier).updateDJTrack(track);
-              showMessageToast(context, response);
-            }
-
-            double newPosition =
-                (value * carouselController.position.viewportDimension) +
-                    carouselController.position.viewportDimension;
-            isShowingPLAYFlame.value = true;
-            if (value == playlist.trackIds.length - 1) {
-              if (playlist.shuffleAtEnd) {
-                playlist = ref
-                    .read(hivePlaylistData.notifier)
-                    .shuffleTracksInPlaylist(playlistId);
-                tracks = ref
-                    .watch(hiveTrackData.notifier)
-                    .getDJTracks(playlist.trackIds);
-                newPosition = 0;
-                isShowingPLAYFlame.value = false;
-                await carouselController.position.animateTo(newPosition,
-                    duration: const Duration(milliseconds: 250),
-                    curve: Curves.easeInOutCubicEmphasized);
-              }
-            } else {
-              await carouselController.position.animateTo(newPosition,
-                  duration: const Duration(milliseconds: 250),
-                  curve: Curves.easeInOutCubicEmphasized);
-              Future.delayed(const Duration(milliseconds: 800), () {
-                isShowingPLAYFlame.value = false;
-              });
-              await ref
-                  .read(lastDjTrackPlayedProvider.notifier)
-                  .updateLastPlayedTrack(track);
-            }
-          },
+          onTap: (value) async => playTrack(value),
           children: List<Widget>.generate(tracks.length, (int trackIdIndex) {
             DJTrack djTrack = tracks[trackIdIndex];
             return LayoutBuilder(
@@ -363,6 +398,36 @@ class DJCenterPlaylistTracksCarousel extends HookConsumerWidget {
                       ],
                     ),
                   ),
+                  if (shortcutKey != null)
+                    Positioned(
+                      top: 3,
+                      right: 3,
+                      child: Container(
+                        width: 30,
+                        height: 30,
+                        decoration: BoxDecoration(
+                          color: playlistType.color,
+                          borderRadius: BorderRadius.circular(7),
+                          boxShadow: const [
+                            BoxShadow(
+                              color: Colors.black26,
+                              blurRadius: 3,
+                              offset: Offset(0, 1),
+                            ),
+                          ],
+                        ),
+                        alignment: Alignment.center,
+                        child: Text(
+                          shortcutKey!.toUpperCase(),
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w900,
+                            fontSize: 15,
+                            color: Colors.white,
+                            height: 1,
+                          ),
+                        ),
+                      ),
+                    ),
                 ],
               ),
             );

--- a/lib/features/djmatch_day/djmatch_day.dart
+++ b/lib/features/djmatch_day/djmatch_day.dart
@@ -10,6 +10,7 @@ import 'package:djsports/features/djmatch_center/widgets/center_control_widget.d
 import 'package:djsports/features/djmatch_day/widgets/debug_log_sheet.dart';
 import 'package:djsports/features/djmatch_day/widgets/match_day_playlist_card.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_volume_controller/flutter_volume_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:toastification/toastification.dart';
@@ -27,8 +28,116 @@ class DJMatchDayViewPage extends StatefulHookConsumerWidget {
 class _DJMatchDayViewPageState extends ConsumerState<DJMatchDayViewPage> {
   bool isPlaying = false;
 
+  final Map<String, ValueNotifier<int>> _playTriggers = {};
+
+  static const _hotspotKeys = ['1', '2', '3', '4', '5', '6'];
+  static const _matchKeys = ['q', 'w', 'e', 'r', 't', 'y'];
+  static const _funStuffKeys = ['a', 's', 'd', 'f', 'g', 'h'];
+
+  static const _hotspotLogicalKeys = [
+    LogicalKeyboardKey.digit1,
+    LogicalKeyboardKey.digit2,
+    LogicalKeyboardKey.digit3,
+    LogicalKeyboardKey.digit4,
+    LogicalKeyboardKey.digit5,
+    LogicalKeyboardKey.digit6,
+  ];
+  static const _matchLogicalKeys = [
+    LogicalKeyboardKey.keyQ,
+    LogicalKeyboardKey.keyW,
+    LogicalKeyboardKey.keyE,
+    LogicalKeyboardKey.keyR,
+    LogicalKeyboardKey.keyT,
+    LogicalKeyboardKey.keyY,
+  ];
+  static const _funStuffLogicalKeys = [
+    LogicalKeyboardKey.keyA,
+    LogicalKeyboardKey.keyS,
+    LogicalKeyboardKey.keyD,
+    LogicalKeyboardKey.keyF,
+    LogicalKeyboardKey.keyG,
+    LogicalKeyboardKey.keyH,
+  ];
+
+  ValueNotifier<int> _getTrigger(String playlistId) =>
+      _playTriggers.putIfAbsent(playlistId, () => ValueNotifier(0));
+
+  String? _shortcutKeyForType(DJPlaylistType type, int index) {
+    if (index >= 6) return null;
+    if (type == DJPlaylistType.hotspot) return _hotspotKeys[index];
+    if (type == DJPlaylistType.match) return _matchKeys[index];
+    if (type == DJPlaylistType.funStuff) return _funStuffKeys[index];
+    return null;
+  }
+
+  bool _handleKeyEvent(KeyEvent event) {
+    if (!AppSettings.keyboardShortcutsEnabled) return false;
+
+    // Consume key-repeat for all our keys to prevent OS beep on held keys
+    if (event is KeyRepeatEvent) {
+      final k = event.logicalKey;
+      return _hotspotLogicalKeys.contains(k) ||
+          _matchLogicalKeys.contains(k) ||
+          _funStuffLogicalKeys.contains(k) ||
+          k == LogicalKeyboardKey.escape ||
+          k == LogicalKeyboardKey.keyP ||
+          k == LogicalKeyboardKey.add ||
+          k == LogicalKeyboardKey.minus;
+    }
+    if (event is! KeyDownEvent) return false;
+
+    final key = event.logicalKey;
+
+    // Global transport controls
+    if (key == LogicalKeyboardKey.escape) {
+      pausePlayer();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.keyP) {
+      resumePlayer();
+      return true;
+    }
+    if (key == LogicalKeyboardKey.add) {
+      ref.read(spotifyRemoteRepositoryProvider).adjustVolume(0.05);
+      return true;
+    }
+    if (key == LogicalKeyboardKey.minus) {
+      ref.read(spotifyRemoteRepositoryProvider).adjustVolume(-0.05);
+      return true;
+    }
+
+    // Playlist shortcuts
+    DJPlaylistType? type;
+    int index = -1;
+
+    if (_hotspotLogicalKeys.contains(key)) {
+      type = DJPlaylistType.hotspot;
+      index = _hotspotLogicalKeys.indexOf(key);
+    } else if (_matchLogicalKeys.contains(key)) {
+      type = DJPlaylistType.match;
+      index = _matchLogicalKeys.indexOf(key);
+    } else if (_funStuffLogicalKeys.contains(key)) {
+      type = DJPlaylistType.funStuff;
+      index = _funStuffLogicalKeys.indexOf(key);
+    }
+
+    if (type == null || index < 0) return false;
+
+    final allPlaylists = ref.read(hivePlaylistData) ?? [];
+    final typePlaylists = allPlaylists
+        .where((p) => p.type == type!.name)
+        .toList()
+      ..sort((a, b) => a.position.compareTo(b.position));
+
+    if (index < typePlaylists.length) {
+      _getTrigger(typePlaylists[index].id).value++;
+    }
+    return true;
+  }
+
   @override
   void initState() {
+    HardwareKeyboard.instance.addHandler(_handleKeyEvent);
     if (!Platform.isMacOS) {
       FlutterVolumeController.addListener((newVolume) {
         final repo = ref.read(spotifyRemoteRepositoryProvider);
@@ -37,11 +146,24 @@ class _DJMatchDayViewPageState extends ConsumerState<DJMatchDayViewPage> {
       });
       FlutterVolumeController.getVolume().then((v) {
         if (v != null && mounted) {
-          ref.read(spotifyRemoteRepositoryProvider).setVolume(v);
-          final pct = (v * 100).round();
+          final repo = ref.read(spotifyRemoteRepositoryProvider);
+          final autoSet = repo.volumeAutoSetToDefault || v == 0;
+          if (autoSet) {
+            repo.volumeAutoSetToDefault = false;
+            if (v == 0) {
+              FlutterVolumeController.setVolume(0.85);
+              repo.setVolume(0.85);
+            }
+          } else {
+            repo.setVolume(v);
+          }
           toastification.show(
             context: context,
-            title: Text('Volume: $pct%'),
+            title: Text(
+              autoSet
+                  ? 'Volume auto-set to 85%'
+                  : 'Volume: ${(v * 100).round()}%',
+            ),
             autoCloseDuration: const Duration(seconds: 3),
             style: ToastificationStyle.flat,
             alignment: Alignment.topCenter,
@@ -54,6 +176,10 @@ class _DJMatchDayViewPageState extends ConsumerState<DJMatchDayViewPage> {
 
   @override
   void dispose() {
+    HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
+    for (final t in _playTriggers.values) {
+      t.dispose();
+    }
     if (!Platform.isMacOS) {
       FlutterVolumeController.removeListener();
     }
@@ -134,11 +260,18 @@ class _DJMatchDayViewPageState extends ConsumerState<DJMatchDayViewPage> {
                   (t) => t.name == playlist.type,
                   orElse: () => DJPlaylistType.match,
                 );
+                final shortcutKey = AppSettings.keyboardShortcutsEnabled
+                    ? _shortcutKeyForType(pType, i)
+                    : null;
                 return MatchDayPlaylistCard(
                   playlistId: playlist.id,
                   playlistName: playlist.name,
                   playlistType: pType,
                   initialTrackIndex: playlist.currentTrack,
+                  shortcutKey: shortcutKey,
+                  playTrigger: shortcutKey != null
+                      ? _getTrigger(playlist.id)
+                      : null,
                 );
               },
             );

--- a/lib/features/djmatch_day/widgets/match_day_playlist_card.dart
+++ b/lib/features/djmatch_day/widgets/match_day_playlist_card.dart
@@ -19,12 +19,16 @@ class MatchDayPlaylistCard extends ConsumerStatefulWidget {
     required this.playlistName,
     required this.playlistType,
     required this.initialTrackIndex,
+    this.shortcutKey,
+    this.playTrigger,
   });
 
   final String playlistId;
   final String playlistName;
   final DJPlaylistType playlistType;
   final int initialTrackIndex;
+  final String? shortcutKey;
+  final ValueNotifier<int>? playTrigger;
 
   @override
   ConsumerState<MatchDayPlaylistCard> createState() =>
@@ -47,13 +51,34 @@ class _MatchDayPlaylistCardState extends ConsumerState<MatchDayPlaylistCard>
       duration: const Duration(milliseconds: 700),
       value: 1.0, // start fully faded — no overlay until first play
     );
+    widget.playTrigger?.addListener(_onKeyboardTrigger);
+  }
+
+  @override
+  void didUpdateWidget(MatchDayPlaylistCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.playTrigger != widget.playTrigger) {
+      oldWidget.playTrigger?.removeListener(_onKeyboardTrigger);
+      widget.playTrigger?.addListener(_onKeyboardTrigger);
+    }
   }
 
   @override
   void dispose() {
+    widget.playTrigger?.removeListener(_onKeyboardTrigger);
     _autoNextTimer?.cancel();
     _flashController.dispose();
     super.dispose();
+  }
+
+  void _onKeyboardTrigger() {
+    if (!mounted) return;
+    final playlist = ref.read(djPlaylistByIdProvider(widget.playlistId));
+    final tracks =
+        ref.read(hiveTrackData.notifier).getDJTracks(playlist.trackIds);
+    if (tracks.isEmpty) return;
+    final idx = _currentIndex.clamp(0, tracks.length - 1);
+    _playTrack(tracks[idx], idx, tracks.length, playlist.shuffleAtEnd);
   }
 
   String _truncate(String text, int max) {
@@ -342,6 +367,38 @@ class _MatchDayPlaylistCardState extends ConsumerState<MatchDayPlaylistCard>
                   ),
                 ),
               ),
+              if (widget.shortcutKey != null)
+                Positioned(
+                  top: 3,
+                  right: 3,
+                  child: IgnorePointer(
+                    child: Container(
+                      width: 26,
+                      height: 26,
+                      decoration: BoxDecoration(
+                        color: borderColor,
+                        borderRadius: BorderRadius.circular(6),
+                        boxShadow: const [
+                          BoxShadow(
+                            color: Colors.black26,
+                            blurRadius: 3,
+                            offset: Offset(0, 1),
+                          ),
+                        ],
+                      ),
+                      alignment: Alignment.center,
+                      child: Text(
+                        widget.shortcutKey!.toUpperCase(),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w900,
+                          fontSize: 13,
+                          color: Colors.white,
+                          height: 1,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
             ],
           ),
         );

--- a/lib/features/track_time/track_time_center_screen.dart
+++ b/lib/features/track_time/track_time_center_screen.dart
@@ -154,22 +154,45 @@ class _EditScreenState extends ConsumerState<TrackTimeCenterScreen> {
 
   Widget _displaySettingsSection(BuildContext context) {
     final sidebarOnRight = AppSettings.sidebarOnRight;
-    return SwitchListTile(
-      title: const Text('Sidebar on right in landscape'),
-      subtitle: Text(
-        sidebarOnRight
-            ? 'Controls are on the right side'
-            : 'Controls are on the left side',
-        style: Theme.of(context).textTheme.bodySmall,
-      ),
-      secondary: Icon(
-        sidebarOnRight ? Icons.align_horizontal_right : Icons.align_horizontal_left,
-      ),
-      value: sidebarOnRight,
-      onChanged: (value) async {
-        await AppSettings.setSidebarOnRight(value);
-        setState(() {});
-      },
+    final keyboardShortcuts = AppSettings.keyboardShortcutsEnabled;
+    return Column(
+      children: [
+        SwitchListTile(
+          title: const Text('Sidebar on right in landscape'),
+          subtitle: Text(
+            sidebarOnRight
+                ? 'Controls are on the right side'
+                : 'Controls are on the left side',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          secondary: Icon(
+            sidebarOnRight
+                ? Icons.align_horizontal_right
+                : Icons.align_horizontal_left,
+          ),
+          value: sidebarOnRight,
+          onChanged: (value) async {
+            await AppSettings.setSidebarOnRight(value);
+            setState(() {});
+          },
+        ),
+        SwitchListTile(
+          title: const Text('Keyboard shortcuts in match center'),
+          subtitle: Text(
+            keyboardShortcuts
+                ? 'Playlists: Hotspot 1-6  •  Match Q-Y  •  Fun A-H\n'
+                    'Transport: P=play  •  ESC=pause  •  +=vol+  •  -=vol-'
+                : 'Enable to use keyboard keys to trigger playlists',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          secondary: const Icon(Icons.keyboard),
+          value: keyboardShortcuts,
+          onChanged: (value) async {
+            await AppSettings.setKeyboardShortcutsEnabled(value);
+            setState(() {});
+          },
+        ),
+      ],
     );
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_volume_controller/flutter_volume_controller_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_volume_controller_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterVolumeControllerPlugin");
   flutter_volume_controller_plugin_register_with_registrar(flutter_volume_controller_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_volume_controller
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import flutter_volume_controller
 import just_audio
 import package_info_plus
 import sqflite_darwin
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
@@ -19,4 +20,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.0.0+10
+version: 3.0.1+11
 
 environment:
   sdk: '>=3.8.0 <4.0.0'
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  url_launcher: ^6.2.6
   toastification: ^3.0.3
   flutter_animate: ^4.5.2
   cupertino_icons: ^1.0.6

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_volume_controller/flutter_volume_controller_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterVolumeControllerPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterVolumeControllerPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_volume_controller
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
…board shortcuts

- Added "Open Spotify" button for Android in the match center control panel, allowing direct app launch via `spotify:` URI.
- Improved volume handling on Android: initialized from the platform on startup, auto-set to 85% when muted, and fixed volume restoration issues after pause/play.
- Upgraded Android Gradle Plugin and Gradle wrapper for compatibility with updated dependencies.
- Introduced keyboard shortcuts for playlist control in the match center, enabling quick access to playlists and transport controls.
- Updated version to 3.0.1+11 and added keyboard shortcuts toggle in settings.