### PR TITLE
Bump version to 3.4.5+22 and update changelog for new help screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5] - Release 2026-04-05
+
+### Added
+- **Playlist Help screen** — step-by-step guide covering: adding playlists
+  with +, setting playlist type, pasting a Spotify URI, syncing tracks, and
+  editing track start times; accessible via the `?` icon in the AppBar (wide)
+  or the ··· popup menu (narrow)
+- **Let's Play Help screen** — guide for the live DJ view covering: tapping a
+  card to start, Auto Next behaviour, browsing tracks with < / >, adjusting
+  volume, and using the ⌫ button to return home; accessible via the `?` icon
+  in the sidebar and compact control bar
+
 ## [3.4.5] - Release 2026-04-03
 
 ### Added

--- a/lib/features/djletsplay/djletsplay.dart
+++ b/lib/features/djletsplay/djletsplay.dart
@@ -8,6 +8,7 @@ import 'package:djsports/data/repo/spotify_remote_repository.dart';
 import 'package:djsports/data/repo/app_settings_repository.dart';
 import 'package:djsports/features/djmatch_center/widgets/center_control_widget.dart';
 import 'package:djsports/features/djletsplay/widgets/debug_log_sheet.dart';
+import 'package:djsports/features/djletsplay/letsplay_help_screen.dart';
 import 'package:djsports/features/djletsplay/widgets/letsplay_playlist_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -328,6 +329,20 @@ class _DJLetsPlayViewPageState extends ConsumerState<DJLetsPlayViewPage> {
             ),
           ),
           IconButton(
+            icon: const Icon(
+              Icons.help_outline,
+              color: Colors.white70,
+              size: 22,
+            ),
+            tooltip: 'Help',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const LetsPlayHelpScreen(),
+              ),
+            ),
+          ),
+          IconButton(
             icon: const Icon(Icons.bug_report, color: Colors.white70, size: 22),
             tooltip: 'Debug log',
             onPressed: () => DebugLogSheet.show(context),
@@ -452,6 +467,20 @@ class _DJLetsPlayViewPageState extends ConsumerState<DJLetsPlayViewPage> {
                 onPressed: () => ref
                     .read(spotifyRemoteRepositoryProvider)
                     .adjustVolume(-0.05),
+              ),
+              IconButton(
+                icon: const Icon(
+                  Icons.help_outline,
+                  color: Colors.white70,
+                  size: 24,
+                ),
+                tooltip: 'Help',
+                onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const LetsPlayHelpScreen(),
+                  ),
+                ),
               ),
               IconButton(
                 icon: const Icon(

--- a/lib/features/djletsplay/letsplay_help_screen.dart
+++ b/lib/features/djletsplay/letsplay_help_screen.dart
@@ -1,0 +1,423 @@
+import 'package:flutter/material.dart';
+
+class LetsPlayHelpScreen extends StatelessWidget {
+  const LetsPlayHelpScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          "Let's Play Help",
+          style: TextStyle(
+            color: Colors.black,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Colors.black),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _HelpHeader(
+                icon: Icons.sports_handball,
+                iconColor: Colors.green.shade700,
+                title: "Let's Play",
+                subtitle:
+                    'Your live DJ control center during the event.',
+              ),
+              const SizedBox(height: 24),
+              const _HelpSection(
+                stepNumber: '1',
+                icon: Icons.touch_app,
+                iconColor: Colors.green,
+                title: 'Start Playing a Playlist',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Tap any playlist card to start playing the current '
+                      'track immediately on Spotify.',
+                    ),
+                    SizedBox(height: 8),
+                    _VisualRow(
+                      icon: Icons.touch_app,
+                      color: Colors.green,
+                      label: 'Tap card → plays current track',
+                    ),
+                    SizedBox(height: 6),
+                    Text(
+                      'The card flashes briefly to confirm playback has '
+                      'started.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '2',
+                icon: Icons.skip_next,
+                iconColor: Colors.blue,
+                title: 'Auto Next Track',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'If the playlist has "Auto Next" enabled, the app '
+                      'will automatically advance to the next track after '
+                      'the configured number of seconds.',
+                    ),
+                    SizedBox(height: 8),
+                    _VisualRow(
+                      icon: Icons.timer,
+                      color: Colors.blue,
+                      label: 'Auto Next: set in playlist options',
+                    ),
+                    SizedBox(height: 6),
+                    Text(
+                      'To enable Auto Next, edit the playlist and turn on '
+                      'the Auto Next toggle before starting the event.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '3',
+                icon: Icons.swap_horiz,
+                iconColor: Colors.purple,
+                title: 'Browse Tracks with < and >',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Each playlist card shows the current track. '
+                      'Use the arrow buttons to navigate through the '
+                      'tracks without playing them.',
+                    ),
+                    SizedBox(height: 10),
+                    Row(
+                      children: [
+                        _ArrowChip(icon: Icons.chevron_left, label: '<'),
+                        SizedBox(width: 10),
+                        Text('Previous track', style: TextStyle(fontSize: 13)),
+                      ],
+                    ),
+                    SizedBox(height: 6),
+                    Row(
+                      children: [
+                        _ArrowChip(icon: Icons.chevron_right, label: '>'),
+                        SizedBox(width: 10),
+                        Text('Next track', style: TextStyle(fontSize: 13)),
+                      ],
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Tap the card after browsing to play the selected '
+                      'track.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '4',
+                icon: Icons.volume_up,
+                iconColor: Colors.orange,
+                title: 'Set Volume',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Use the volume buttons in the control bar to adjust '
+                      'the Spotify playback volume.',
+                    ),
+                    SizedBox(height: 10),
+                    Row(
+                      children: [
+                        _ControlChip(
+                          icon: Icons.volume_up,
+                          color: Colors.orange,
+                        ),
+                        SizedBox(width: 6),
+                        Text(
+                          'Volume up (+5%)',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 6),
+                    Row(
+                      children: [
+                        _ControlChip(
+                          icon: Icons.volume_down,
+                          color: Colors.orange,
+                        ),
+                        SizedBox(width: 6),
+                        Text(
+                          'Volume down (−5%)',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'The current volume level is shown in the app bar '
+                      'on the home screen.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '5',
+                icon: Icons.backspace,
+                iconColor: Colors.red,
+                title: 'Back to Home',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Tap the back button (⌫) in the control bar to exit '
+                      "Let's Play and return to the home screen.",
+                    ),
+                    SizedBox(height: 8),
+                    _ControlChip(
+                      icon: Icons.backspace,
+                      color: Colors.red,
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Music will keep playing in Spotify — use the pause '
+                      'button before going back if you want to stop.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 32),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HelpHeader extends StatelessWidget {
+  const _HelpHeader({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            color: iconColor.withAlpha(26),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: iconColor.withAlpha(77)),
+          ),
+          child: Icon(icon, color: iconColor, size: 28),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _HelpSection extends StatelessWidget {
+  const _HelpSection({
+    required this.stepNumber,
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.body,
+  });
+
+  final String stepNumber;
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: iconColor,
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    stepNumber,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Icon(icon, color: iconColor, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          DefaultTextStyle(
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey.shade800,
+              height: 1.5,
+            ),
+            child: body,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VisualRow extends StatelessWidget {
+  const _VisualRow({
+    required this.icon,
+    required this.color,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withAlpha(20),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withAlpha(60)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              color: color,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ArrowChip extends StatelessWidget {
+  const _ArrowChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 36,
+      decoration: BoxDecoration(
+        color: Colors.grey.shade200,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: Icon(icon, size: 20, color: Colors.grey.shade700),
+    );
+  }
+}
+
+class _ControlChip extends StatelessWidget {
+  const _ControlChip({required this.icon, required this.color});
+
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 36,
+      decoration: BoxDecoration(
+        color: color.withAlpha(26),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withAlpha(77)),
+      ),
+      child: Icon(icon, size: 20, color: color),
+    );
+  }
+}

--- a/lib/features/djsports/djsports_home_page.dart
+++ b/lib/features/djsports/djsports_home_page.dart
@@ -8,6 +8,7 @@ import 'package:djsports/data/provider/djtrack_provider.dart';
 import 'package:djsports/data/repo/spotify_remote_repository.dart';
 import 'package:djsports/data/services/spotify_platform_bridge.dart';
 import 'package:djsports/features/cloud_backup/cloud_backup_screen.dart';
+import 'package:djsports/features/djsports/playlist_help_screen.dart';
 import 'package:djsports/features/djletsplay/djletsplay.dart';
 import 'package:djsports/features/djmatch_center/widgets/current_volume_widget.dart';
 import 'package:djsports/features/djsports/first_time_use_screen.dart';
@@ -152,6 +153,8 @@ class _HomePageState extends ConsumerState<HomePage> {
         _navigateTo(TrackTimeCenterScreen());
       case 'cloudbackup':
         _navigateTo(CloudBackupScreen(refreshCallback: () => setState(() {})));
+      case 'playlisthelp':
+        _navigateTo(const PlaylistHelpScreen());
     }
   }
 
@@ -202,6 +205,13 @@ class _HomePageState extends ConsumerState<HomePage> {
         child: IconButton(
           icon: const Icon(Icons.settings, color: Colors.black),
           onPressed: () => _navigateTo(TrackTimeCenterScreen()),
+        ),
+      ),
+      Tooltip(
+        message: 'Playlist help',
+        child: IconButton(
+          icon: const Icon(Icons.help_outline, color: Colors.black54),
+          onPressed: () => _navigateTo(const PlaylistHelpScreen()),
         ),
       ),
       Tooltip(
@@ -335,6 +345,16 @@ class _HomePageState extends ConsumerState<HomePage> {
                 Icon(Icons.cloud),
                 SizedBox(width: 10),
                 Text('Cloud Backup'),
+              ],
+            ),
+          ),
+          const PopupMenuItem(
+            value: 'playlisthelp',
+            child: Row(
+              children: [
+                Icon(Icons.help_outline),
+                SizedBox(width: 10),
+                Text('Playlist Help'),
               ],
             ),
           ),

--- a/lib/features/djsports/playlist_help_screen.dart
+++ b/lib/features/djsports/playlist_help_screen.dart
@@ -1,0 +1,447 @@
+import 'package:flutter/material.dart';
+
+class PlaylistHelpScreen extends StatelessWidget {
+  const PlaylistHelpScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Playlist Help',
+          style: TextStyle(
+            color: Colors.black,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Colors.black),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _HelpHeader(
+                icon: Icons.queue_music,
+                iconColor: Colors.green.shade700,
+                title: 'Managing Playlists',
+                subtitle:
+                    'Set up your playlists with Spotify tracks for the event.',
+              ),
+              const SizedBox(height: 24),
+              const _HelpSection(
+                stepNumber: '1',
+                icon: Icons.add,
+                iconColor: Colors.black,
+                title: 'Add a New Playlist',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Tap the + button in the top-right of the home screen to '
+                      'create a new playlist.',
+                    ),
+                    SizedBox(height: 8),
+                    _InlineChip(icon: Icons.add, label: '+ New Playlist'),
+                    SizedBox(height: 8),
+                    Text('Give the playlist a name that makes it easy to '
+                        'identify during the event.'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _HelpSection(
+                stepNumber: '2',
+                icon: Icons.label,
+                iconColor: Colors.purple,
+                title: 'Set the Playlist Type',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Choose the type that fits when this playlist will be '
+                      'played:',
+                    ),
+                    const SizedBox(height: 10),
+                    _TypeRow(
+                      color: Colors.red,
+                      label: 'Hotspot',
+                      description: 'High-energy moments',
+                    ),
+                    _TypeRow(
+                      color: Colors.green.shade700,
+                      label: 'Match',
+                      description: 'During gameplay',
+                    ),
+                    _TypeRow(
+                      color: Colors.blue,
+                      label: 'Fun Stuff',
+                      description: 'Entertainment breaks',
+                    ),
+                    _TypeRow(
+                      color: Colors.black,
+                      label: 'Pre-Match',
+                      description: 'Pre-game atmosphere',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '3',
+                icon: Icons.link,
+                iconColor: Colors.teal,
+                title: 'Paste the Spotify URI',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Open Spotify and find the playlist you want to use. '
+                      'Copy its URI:',
+                    ),
+                    SizedBox(height: 8),
+                    _StepItem(
+                      text:
+                          'In Spotify: tap ··· on a playlist → Share → Copy '
+                          'Spotify URI',
+                    ),
+                    _StepItem(
+                      text:
+                          'The URI looks like: spotify:playlist:37i9dQZF…',
+                    ),
+                    _StepItem(
+                      text: 'Paste it into the Spotify URI field in the '
+                          'playlist editor.',
+                    ),
+                    SizedBox(height: 8),
+                    _InlineChip(
+                      icon: Icons.content_paste,
+                      label: 'Spotify URI field',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '4',
+                icon: Icons.sync,
+                iconColor: Colors.green,
+                title: 'Sync Tracks from Spotify',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'After pasting the URI, tap the Sync button to import '
+                      'all tracks from that Spotify playlist.',
+                    ),
+                    SizedBox(height: 8),
+                    _InlineChip(icon: Icons.sync, label: 'Sync'),
+                    SizedBox(height: 8),
+                    Text(
+                      'The app will fetch the tracks and add them to your '
+                      'playlist. This requires a Spotify connection.',
+                    ),
+                    SizedBox(height: 8),
+                    _StepItem(
+                      text: 'You can re-sync later to pick up new tracks '
+                          'added to the Spotify playlist.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _HelpSection(
+                stepNumber: '5',
+                icon: Icons.timer,
+                iconColor: Colors.orange,
+                title: 'Edit Track Start Times',
+                body: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Each track can have a custom start time so playback '
+                      'begins at the best moment of the song.',
+                    ),
+                    SizedBox(height: 8),
+                    _StepItem(
+                      text: 'Tap a track in the playlist to open the track '
+                          'editor.',
+                    ),
+                    _StepItem(
+                      text: 'Use the start time slider to set minutes and '
+                          'seconds.',
+                    ),
+                    _StepItem(
+                      text: 'Save the track — the start time will be used '
+                          'every time that track plays.',
+                    ),
+                    SizedBox(height: 8),
+                    _InlineChip(icon: Icons.access_time, label: 'Start time'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 32),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HelpHeader extends StatelessWidget {
+  const _HelpHeader({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            color: iconColor.withAlpha(26),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: iconColor.withAlpha(77)),
+          ),
+          child: Icon(icon, color: iconColor, size: 28),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                subtitle,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _HelpSection extends StatelessWidget {
+  const _HelpSection({
+    required this.stepNumber,
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.body,
+  });
+
+  final String stepNumber;
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: iconColor,
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    stepNumber,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Icon(icon, color: iconColor, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          DefaultTextStyle(
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey.shade800,
+              height: 1.5,
+            ),
+            child: body,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TypeRow extends StatelessWidget {
+  const _TypeRow({
+    required this.color,
+    required this.label,
+    required this.description,
+  });
+
+  final Color color;
+  final String label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Container(
+            width: 12,
+            height: 12,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 13,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '— $description',
+            style: TextStyle(
+              fontSize: 13,
+              color: Colors.grey.shade600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepItem extends StatelessWidget {
+  const _StepItem({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 5),
+            child: Container(
+              width: 5,
+              height: 5,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade500,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(text),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InlineChip extends StatelessWidget {
+  const _InlineChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.grey.shade300),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade200,
+            blurRadius: 2,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: Colors.grey.shade700),
+          const SizedBox(width: 5),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              color: Colors.grey.shade700,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.4.4+21
+version: 3.4.5+22
 
 environment:
   sdk: '>=3.8.0 <4.0.0'


### PR DESCRIPTION
- Added Playlist Help screen with detailed instructions for managing playlists.
- Introduced Let's Play Help screen covering live DJ controls and features.
- Updated pubspec.yaml to reflect new versioning.
- Integrated help screens into the DJLetsPlay and DJSports home pages with accessible help icons.